### PR TITLE
Add styleTransitionWillBegin/DidEnd to GagatStyleable

### DIFF
--- a/Gagat Example/ArchiveTableViewController.swift
+++ b/Gagat Example/ArchiveTableViewController.swift
@@ -77,6 +77,14 @@ class ArchiveTableViewController: UITableViewController, UIGestureRecognizerDele
 
 extension ArchiveTableViewController: GagatStyleable {
 
+	func styleTransitionWillBegin() {
+		// Do any work you might need to do before the transition snapshot is taken.
+	}
+
+	func styleTransitionDidEnd() {
+		// Do any work you might need to do once the transition has completed.
+	}
+
 	func toggleActiveStyle() {
 		useDarkMode = !useDarkMode
 	}

--- a/Gagat Example/ArchiveTableViewController.swift
+++ b/Gagat Example/ArchiveTableViewController.swift
@@ -77,14 +77,6 @@ class ArchiveTableViewController: UITableViewController, UIGestureRecognizerDele
 
 extension ArchiveTableViewController: GagatStyleable {
 
-	func styleTransitionWillBegin() {
-		// Do any work you might need to do before the transition snapshot is taken.
-	}
-
-	func styleTransitionDidEnd() {
-		// Do any work you might need to do once the transition has completed.
-	}
-
 	func toggleActiveStyle() {
 		useDarkMode = !useDarkMode
 	}

--- a/Gagat Example/StyleableNavigationController.swift
+++ b/Gagat Example/StyleableNavigationController.swift
@@ -42,6 +42,21 @@ class StyleableNavigationController: UINavigationController {
 }
 
 extension StyleableNavigationController: GagatStyleable {
+
+	func styleTransitionWillBegin() {
+		// Do any work you might need to do before the transition snapshot is taken.
+		if let styleableChildViewController = topViewController as? GagatStyleable {
+			styleableChildViewController.styleTransitionWillBegin()
+		}
+	}
+
+	func styleTransitionDidEnd() {
+		// Do any work you might need to do once the transition has completed.
+		if let styleableChildViewController = topViewController as? GagatStyleable {
+			styleableChildViewController.styleTransitionDidEnd()
+		}
+	}
+
 	func toggleActiveStyle() {
 		useDarkMode = !useDarkMode
 

--- a/Gagat.xcodeproj/project.pbxproj
+++ b/Gagat.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 				9386EDDB1E577236009079B6 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		9386EDDB1E577236009079B6 /* Products */ = {
 			isa = PBXGroup;

--- a/Gagat/Gagat.swift
+++ b/Gagat/Gagat.swift
@@ -17,6 +17,12 @@ public protocol GagatStyleable {
 	/// and at the end of a _cancelled_ transition (to revert to the
 	/// previous style).
 	func toggleActiveStyle()
+
+	/// Called when the style transition is about to begin. `toggleActiveStyle()` will be called just after this.
+	func styleTransitionWillBegin()
+
+	/// Called when the style transition ended.
+	func styleTransitionDidEnd()
 }
 
 public struct Gagat {

--- a/Gagat/Gagat.swift
+++ b/Gagat/Gagat.swift
@@ -25,6 +25,14 @@ public protocol GagatStyleable {
 	func styleTransitionDidEnd()
 }
 
+/// Since styleTransitionWillBegin() and styleTransitionDidEnd() aren't considered as required to implement
+/// the core functionality of the GagatStyleable protocol, this extension provides default (empty) implementations
+/// of those functions. This makes implementing them in your GagatStyleable object optional.
+public extension GagatStyleable {
+	func styleTransitionWillBegin() {}
+	func styleTransitionDidEnd() {}
+}
+
 public struct Gagat {
 
 	/// The `Configuration` struct allows clients to configure certain

--- a/Gagat/TransitionCoordinator.swift
+++ b/Gagat/TransitionCoordinator.swift
@@ -85,6 +85,10 @@ class TransitionCoordinator: NSObject {
 	private var snapshotMaskLayer: CAShapeLayer?
 	
 	private func beginInteractiveStyleTransition(withPanRecognizer panRecognizer: PessimisticPanGestureRecognizer) {
+
+		// Inform our object that we're about to start a transition.
+		styleableObject.styleTransitionWillBegin()
+
 		// We snapshot the targetView before applying the new style, and make sure
 		// it's positioned on top of all the other content.
 		previousStyleTargetViewSnapshot = targetView.snapshotView(afterScreenUpdates: false)
@@ -205,6 +209,7 @@ class TransitionCoordinator: NSObject {
 		styleableObject.toggleActiveStyle()
 		cleanupAfterInteractiveStyleTransition()
 		state = .idle
+		styleableObject.styleTransitionDidEnd()
 	}
 	
 	private func cancelInteractiveStyleTransition(withVelocity velocity: CGPoint) {
@@ -221,6 +226,7 @@ class TransitionCoordinator: NSObject {
 			self.styleableObject.toggleActiveStyle()
 			self.cleanupAfterInteractiveStyleTransition()
 			self.state = .idle
+			self.styleableObject.styleTransitionDidEnd()
 		}
 	}
 	
@@ -240,6 +246,7 @@ class TransitionCoordinator: NSObject {
 		animate(snapshotMaskLayer, to: targetLocation, withVelocity: velocity) {
 			self.cleanupAfterInteractiveStyleTransition()
 			self.state = .idle
+			self.styleableObject.styleTransitionDidEnd()
 		}
 	}
 	

--- a/GagatObjectiveC/Gagat.swift
+++ b/GagatObjectiveC/Gagat.swift
@@ -23,7 +23,13 @@ import Gagat
 	/// This method is called by Gagat at the start of a transition
 	/// and at the end of a _cancelled_ transition (to revert to the
 	/// previous style).
-	func toggleActiveStyle()
+	@objc func toggleActiveStyle()
+
+	/// Called when the style transition is about to begin. `toggleActiveStyle()` will be called just after this.
+	@objc optional func styleTransitionWillBegin()
+
+	/// Called when the style transition ended.
+	@objc optional func styleTransitionDidEnd()
 }
 
 /// The `GGTConfiguration` class allows clients to configure certain
@@ -115,5 +121,17 @@ private struct GagatStyleableSwiftToObjCProxy: GagatStyleable {
 
 	func toggleActiveStyle() {
 		target.toggleActiveStyle()
+	}
+
+	func styleTransitionWillBegin() {
+		if let targetImplementation = target.styleTransitionWillBegin {
+			targetImplementation()
+		}
+	}
+
+	func styleTransitionDidEnd() {
+		if let targetImplementation = target.styleTransitionDidEnd {
+			targetImplementation()
+		}
 	}
 }


### PR DESCRIPTION
This PR adds two methods to `GagatStyleable` - `styleTransitionWillBegin()` and `styleTransitionDidEnd()`.

The reasoning for adding this is this fellow: 

<p align="center"><img src="https://user-images.githubusercontent.com/514900/32605286-2a66e1b0-c551-11e7-80cd-9e1a71d36672.png" width="407"></p>

If your app changes its icon in response to theme changes, this dialog will pop up. The UIKit API for this is async, and the dialog can appear on top of the Gagat transition or as part of the snapshot, depending on when UIKit decides to show it.

These additions allow apps to hold back on icon changes (and other things) while the transition is in progress.

This PR also adds the "Use tabs" setting to the project, so people like me don't have to notice after pushing and do a force push to fix incorrect indenting 😉

**Note:** `styleTransitionWillBegin()` and `styleTransitionDidEnd()` are optional in `GGTStyleable`, but not in `GagatStyleable` since optional protocol methods aren't a thing in Swift.