### PR TITLE
Swift 4.2

### DIFF
--- a/Gagat Example/AppDelegate.swift
+++ b/Gagat Example/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	var window: UIWindow?
 	private var transitionHandle: Gagat.TransitionHandle!
 
-	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		// Configure Gagat for the applications only window using a jelly factor that is
 		// slightly larger than the default factor of 1.0. We'll use the root view controller
 		// as the styleable object, but you can use any object that conforms to `GagatStyleable`.

--- a/Gagat Example/StyleableNavigationController.swift
+++ b/Gagat Example/StyleableNavigationController.swift
@@ -11,34 +11,11 @@ import Gagat
 
 class StyleableNavigationController: UINavigationController {
 
-	private struct Style {
-		var navigationBarStyle: UIBarStyle
-		var statusBarStyle: UIStatusBarStyle
-
-		static let dark = Style(
-			navigationBarStyle: .black,
-			statusBarStyle: .lightContent
-		)
-
-		static let light = Style(
-			navigationBarStyle: .default,
-			statusBarStyle: .default
-		)
-	}
-
-	private var currentStyle: Style {
-		return useDarkMode ? .dark : .light
-	}
-
 	fileprivate var useDarkMode = false {
-		didSet { apply(currentStyle) }
+		didSet {
+			navigationBar.barStyle = useDarkMode ? .black : .default
+		}
 	}
-
-	private func apply(_ style: Style) {
-		navigationBar.barStyle = style.navigationBarStyle
-		UIApplication.shared.statusBarStyle = style.statusBarStyle
-	}
-
 }
 
 extension StyleableNavigationController: GagatStyleable {

--- a/Gagat.xcodeproj/project.pbxproj
+++ b/Gagat.xcodeproj/project.pbxproj
@@ -24,6 +24,15 @@
 		939006A51EE2B15D00BF6787 /* ArchiveTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939006A41EE2B15D00BF6787 /* ArchiveTableViewController.swift */; };
 		939006A71EE2B17800BF6787 /* ArchiveTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939006A61EE2B17800BF6787 /* ArchiveTableCellView.swift */; };
 		939006A91EE2B36100BF6787 /* StyleableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939006A81EE2B36100BF6787 /* StyleableNavigationController.swift */; };
+		A5C93695217C82D100776DFC /* StyleableNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = A5C9368B217C82D100776DFC /* StyleableNavigationController.m */; };
+		A5C93697217C82D100776DFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5C9368D217C82D100776DFC /* Assets.xcassets */; };
+		A5C93698217C82D100776DFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5C9368E217C82D100776DFC /* LaunchScreen.storyboard */; };
+		A5C9369A217C82D100776DFC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A5C93692217C82D100776DFC /* AppDelegate.m */; };
+		A5C9369D217C83DE00776DFC /* GagatObjectiveC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9355030B1EF2F4CA00FD428F /* GagatObjectiveC.framework */; };
+		A5C9369E217C83DE00776DFC /* GagatObjectiveC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9355030B1EF2F4CA00FD428F /* GagatObjectiveC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A5C936C6217C84C500776DFC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A5C936C5217C84C500776DFC /* main.m */; };
+		A5C936CC217C8EC800776DFC /* StyleableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A5C936CB217C8EC800776DFC /* StyleableViewController.m */; };
+		A5C936CE217C924A00776DFC /* Gagat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9390063E1EE2038900BF6787 /* Gagat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +50,20 @@
 			remoteGlobalIDString = 9390063D1EE2038900BF6787;
 			remoteInfo = Gagat;
 		};
+		A5C9369F217C83DE00776DFC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9386EDD21E577236009079B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9355030A1EF2F4CA00FD428F;
+			remoteInfo = GagatObjectiveC;
+		};
+		A5C936CF217C924A00776DFC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9386EDD21E577236009079B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9390063D1EE2038900BF6787;
+			remoteInfo = Gagat;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -51,6 +74,18 @@
 			dstSubfolderSpec = 10;
 			files = (
 				939006471EE2038900BF6787 /* Gagat.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A5C936A1217C83DE00776DFC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A5C9369E217C83DE00776DFC /* GagatObjectiveC.framework in Embed Frameworks */,
+				A5C936CE217C924A00776DFC /* Gagat.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -78,6 +113,17 @@
 		939006A41EE2B15D00BF6787 /* ArchiveTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveTableViewController.swift; sourceTree = "<group>"; };
 		939006A61EE2B17800BF6787 /* ArchiveTableCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveTableCellView.swift; sourceTree = "<group>"; };
 		939006A81EE2B36100BF6787 /* StyleableNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleableNavigationController.swift; sourceTree = "<group>"; };
+		A5C93685217C826A00776DFC /* GagatObjectiveC Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GagatObjectiveC Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5C9368B217C82D100776DFC /* StyleableNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StyleableNavigationController.m; sourceTree = "<group>"; };
+		A5C9368D217C82D100776DFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A5C9368F217C82D100776DFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		A5C93692217C82D100776DFC /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		A5C93693217C82D100776DFC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A5C936C4217C847200776DFC /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		A5C936C5217C84C500776DFC /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		A5C936C9217C8A1B00776DFC /* StyleableNavigationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleableNavigationController.h; sourceTree = "<group>"; };
+		A5C936CA217C8EC800776DFC /* StyleableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleableViewController.h; sourceTree = "<group>"; };
+		A5C936CB217C8EC800776DFC /* StyleableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StyleableViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +150,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A5C9367A217C826A00776DFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5C9369D217C83DE00776DFC /* GagatObjectiveC.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -122,6 +176,7 @@
 			children = (
 				9390061F1EE2024700BF6787 /* Gagat Example */,
 				9390063F1EE2038900BF6787 /* Gagat */,
+				A5C93689217C82D100776DFC /* GagatObjectiveC Example */,
 				9355030C1EF2F4CA00FD428F /* GagatObjectiveC */,
 				9386EDDB1E577236009079B6 /* Products */,
 			);
@@ -134,6 +189,7 @@
 				9386EDDA1E577236009079B6 /* Gagat Example.app */,
 				9390063E1EE2038900BF6787 /* Gagat.framework */,
 				9355030B1EF2F4CA00FD428F /* GagatObjectiveC.framework */,
+				A5C93685217C826A00776DFC /* GagatObjectiveC Example.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -164,6 +220,23 @@
 				939006411EE2038900BF6787 /* Info.plist */,
 			);
 			path = Gagat;
+			sourceTree = "<group>";
+		};
+		A5C93689217C82D100776DFC /* GagatObjectiveC Example */ = {
+			isa = PBXGroup;
+			children = (
+				A5C936C5217C84C500776DFC /* main.m */,
+				A5C936C4217C847200776DFC /* AppDelegate.h */,
+				A5C93692217C82D100776DFC /* AppDelegate.m */,
+				A5C936C9217C8A1B00776DFC /* StyleableNavigationController.h */,
+				A5C9368B217C82D100776DFC /* StyleableNavigationController.m */,
+				A5C936CA217C8EC800776DFC /* StyleableViewController.h */,
+				A5C936CB217C8EC800776DFC /* StyleableViewController.m */,
+				A5C9368D217C82D100776DFC /* Assets.xcassets */,
+				A5C9368E217C82D100776DFC /* LaunchScreen.storyboard */,
+				A5C93693217C82D100776DFC /* Info.plist */,
+			);
+			path = "GagatObjectiveC Example";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -244,6 +317,26 @@
 			productReference = 9390063E1EE2038900BF6787 /* Gagat.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		A5C93672217C826A00776DFC /* GagatObjectiveC Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A5C93682217C826A00776DFC /* Build configuration list for PBXNativeTarget "GagatObjectiveC Example" */;
+			buildPhases = (
+				A5C93675217C826A00776DFC /* Sources */,
+				A5C9367A217C826A00776DFC /* Frameworks */,
+				A5C9367C217C826A00776DFC /* Resources */,
+				A5C936A1217C83DE00776DFC /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5C936A0217C83DE00776DFC /* PBXTargetDependency */,
+				A5C936D0217C924A00776DFC /* PBXTargetDependency */,
+			);
+			name = "GagatObjectiveC Example";
+			productName = Gagat;
+			productReference = A5C93685217C826A00776DFC /* GagatObjectiveC Example.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -286,6 +379,7 @@
 			targets = (
 				9386EDD91E577236009079B6 /* Gagat Example */,
 				9390063D1EE2038900BF6787 /* Gagat */,
+				A5C93672217C826A00776DFC /* GagatObjectiveC Example */,
 				9355030A1EF2F4CA00FD428F /* GagatObjectiveC */,
 			);
 		};
@@ -313,6 +407,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A5C9367C217C826A00776DFC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5C93697217C82D100776DFC /* Assets.xcassets in Resources */,
+				A5C93698217C82D100776DFC /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,6 +452,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A5C93675217C826A00776DFC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5C936CC217C8EC800776DFC /* StyleableViewController.m in Sources */,
+				A5C936C6217C84C500776DFC /* main.m in Sources */,
+				A5C9369A217C82D100776DFC /* AppDelegate.m in Sources */,
+				A5C93695217C82D100776DFC /* StyleableNavigationController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -361,6 +475,16 @@
 			isa = PBXTargetDependency;
 			target = 9390063D1EE2038900BF6787 /* Gagat */;
 			targetProxy = 939006431EE2038900BF6787 /* PBXContainerItemProxy */;
+		};
+		A5C936A0217C83DE00776DFC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9355030A1EF2F4CA00FD428F /* GagatObjectiveC */;
+			targetProxy = A5C9369F217C83DE00776DFC /* PBXContainerItemProxy */;
+		};
+		A5C936D0217C924A00776DFC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9390063D1EE2038900BF6787 /* Gagat */;
+			targetProxy = A5C936CF217C924A00776DFC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -381,6 +505,14 @@
 			name = Main.storyboard;
 			sourceTree = "<group>";
 		};
+		A5C9368E217C82D100776DFC /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A5C9368F217C82D100776DFC /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -392,6 +524,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -417,6 +550,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -623,6 +757,36 @@
 			};
 			name = Release;
 		};
+		A5C93683217C826A00776DFC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "GagatObjectiveC Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.GagatObjCExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		A5C93684217C826A00776DFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "GagatObjectiveC Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.GagatObjCExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -658,6 +822,15 @@
 			buildConfigurations = (
 				939006491EE2038900BF6787 /* Debug */,
 				9390064A1EE2038900BF6787 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A5C93682217C826A00776DFC /* Build configuration list for PBXNativeTarget "GagatObjectiveC Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A5C93683217C826A00776DFC /* Debug */,
+				A5C93684217C826A00776DFC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Gagat.xcodeproj/project.pbxproj
+++ b/Gagat.xcodeproj/project.pbxproj
@@ -349,17 +349,17 @@
 				TargetAttributes = {
 					9355030A1EF2F4CA00FD428F = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					9386EDD91E577236009079B6 = {
 						CreatedOnToolsVersion = 8.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					9390063D1EE2038900BF6787 = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -536,7 +536,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -561,7 +561,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.GagatObjectiveC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -687,7 +687,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.GagatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -702,7 +702,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.GagatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -726,7 +726,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -751,7 +751,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = se.cocoabeans.Gagat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Gagat.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Gagat.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Gagat/TransitionCoordinator.swift
+++ b/Gagat/TransitionCoordinator.swift
@@ -54,7 +54,7 @@ class TransitionCoordinator: NSObject {
 		self.panGestureRecognizer = panGestureRecognizer
 	}
 	
-	func panRecognizerDidChange(_ panRecognizer: PessimisticPanGestureRecognizer) {
+	@objc func panRecognizerDidChange(_ panRecognizer: PessimisticPanGestureRecognizer) {
 		switch panRecognizer.state {
 		case .began:
 			beginInteractiveStyleTransition(withPanRecognizer: panRecognizer)
@@ -93,7 +93,7 @@ class TransitionCoordinator: NSObject {
 		// it's positioned on top of all the other content.
 		previousStyleTargetViewSnapshot = targetView.snapshotView(afterScreenUpdates: false)
 		targetView.addSubview(previousStyleTargetViewSnapshot!)
-		targetView.bringSubview(toFront: previousStyleTargetViewSnapshot!)
+		targetView.bringSubviewToFront(previousStyleTargetViewSnapshot!)
 		
 		// When we have the snapshot we create a new mask layer that's used to
 		// control how much of the previous view we display as the transition

--- a/GagatObjectiveC Example/AppDelegate.h
+++ b/GagatObjectiveC Example/AppDelegate.h
@@ -1,0 +1,6 @@
+@import UIKit;
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@end
+

--- a/GagatObjectiveC Example/AppDelegate.m
+++ b/GagatObjectiveC Example/AppDelegate.m
@@ -1,0 +1,36 @@
+#import "AppDelegate.h"
+#import "StyleableNavigationController.h"
+#import "StyleableViewController.h"
+@import GagatObjectiveC.Swift;
+
+@interface AppDelegate ()
+
+@property (nonatomic) GGTTransitionHandle *transitionHandle;
+
+@end
+
+@implementation AppDelegate
+
+@synthesize window = _window;
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+	self.window = [[UIWindow alloc] init];
+
+	StyleableNavigationController *navigationController = [[StyleableNavigationController alloc] initWithRootViewController:[[StyleableViewController alloc] init]];
+	self.window.rootViewController = navigationController;
+
+	// Configure Gagat for the applications only window using a jelly factor that is
+	// slightly larger than the default factor of 1.0. We'll use the root view controller
+	// as the styleable object, but you can use any object that conforms to `GGTStyleable`.
+	//
+	// Note: Make sure you keep a reference to the value returned from `configureForWindow:withStyleableObject:usingConfiguration:`.
+	// If this object is deallocated then the Gagat transition will no longer work.
+	GGTConfiguration *configuration = [[GGTConfiguration alloc] initWithJellyFactor:1.5];
+	self.transitionHandle = [GGTManager configureForWindow:self.window withStyleableObject:navigationController usingConfiguration:configuration];
+
+	[self.window makeKeyAndVisible];
+
+	return YES;
+}
+
+@end

--- a/GagatObjectiveC Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GagatObjectiveC Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GagatObjectiveC Example/Assets.xcassets/Contents.json
+++ b/GagatObjectiveC Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GagatObjectiveC Example/Base.lproj/LaunchScreen.storyboard
+++ b/GagatObjectiveC Example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/GagatObjectiveC Example/Info.plist
+++ b/GagatObjectiveC Example/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/GagatObjectiveC Example/StyleableNavigationController.h
+++ b/GagatObjectiveC Example/StyleableNavigationController.h
@@ -1,0 +1,6 @@
+@import UIKit;
+@import GagatObjectiveC.Swift;
+
+@interface StyleableNavigationController: UINavigationController <GGTStyleable>
+
+@end

--- a/GagatObjectiveC Example/StyleableNavigationController.m
+++ b/GagatObjectiveC Example/StyleableNavigationController.m
@@ -1,0 +1,46 @@
+#import "StyleableNavigationController.h"
+
+@interface StyleableNavigationController ()
+
+@property (nonatomic) BOOL useDarkMode;
+
+@end
+
+@implementation StyleableNavigationController
+
+- (void)styleTransitionWillBegin {
+	// Do any work you might need to do once the transition has completed.
+	UIViewController *topViewController = self.topViewController;
+	if ([topViewController conformsToProtocol:@protocol(GGTStyleable)]) {
+		[(id<GGTStyleable>)topViewController styleTransitionWillBegin];
+	}
+}
+
+- (void)styleTransitionDidEnd {
+	// Do any work you might need to do once the transition has completed.
+	UIViewController *topViewController = self.topViewController;
+	if ([topViewController conformsToProtocol:@protocol(GGTStyleable)]) {
+		[(id<GGTStyleable>)topViewController styleTransitionDidEnd];
+	}
+}
+
+- (void)toggleActiveStyle {
+	self.useDarkMode = !self.useDarkMode;
+
+	// It's up to us to get any child view controllers to
+	// toggle their active style. In this example application we've made
+	// the child view controller also conform to `GGTStyleable`, but
+	// this is not required by Gagat.
+	UIViewController *topViewController = self.topViewController;
+	if ([topViewController conformsToProtocol:@protocol(GGTStyleable)]) {
+		[(id<GGTStyleable>)topViewController toggleActiveStyle];
+	}
+}
+
+- (void)setUseDarkMode:(BOOL)useDarkMode {
+	_useDarkMode = useDarkMode;
+
+	self.navigationBar.barStyle = useDarkMode ? UIBarStyleBlack : UIBarStyleDefault;
+}
+
+@end

--- a/GagatObjectiveC Example/StyleableViewController.h
+++ b/GagatObjectiveC Example/StyleableViewController.h
@@ -1,0 +1,6 @@
+@import UIKit;
+@import GagatObjectiveC.Swift;
+
+@interface StyleableViewController: UIViewController <GGTStyleable>
+
+@end

--- a/GagatObjectiveC Example/StyleableViewController.m
+++ b/GagatObjectiveC Example/StyleableViewController.m
@@ -1,0 +1,49 @@
+#import "StyleableViewController.h"
+
+@interface StyleableViewController ()
+
+@property (nonatomic) BOOL useDarkMode;
+@property (nonatomic) UILabel *label;
+
+@end
+
+@implementation StyleableViewController
+
+- (void)loadView {
+	self.label = [[UILabel alloc] init];
+	self.label.text = @"Gagat";
+	self.label.textAlignment = NSTextAlignmentCenter;
+	self.view = self.label;
+
+	self.title = @"Gagat";
+}
+
+- (void)viewDidLoad {
+	[super viewDidLoad];
+
+	[self applyStyle];
+}
+
+- (void)styleTransitionWillBegin {
+	// Do any work you might need to do once the transition has completed.
+}
+
+- (void)styleTransitionDidEnd {
+	// Do any work you might need to do once the transition has completed.
+}
+
+- (void)toggleActiveStyle {
+	self.useDarkMode = !self.useDarkMode;
+}
+
+- (void)setUseDarkMode:(BOOL)useDarkMode {
+	_useDarkMode = useDarkMode;
+	[self applyStyle];
+}
+
+- (void)applyStyle {
+	self.view.backgroundColor = self.useDarkMode ? [UIColor colorWithWhite:0.15f alpha:1] : UIColor.whiteColor;
+	self.label.textColor = self.useDarkMode ? UIColor.lightTextColor : UIColor.darkTextColor;
+}
+
+@end

--- a/GagatObjectiveC Example/main.m
+++ b/GagatObjectiveC Example/main.m
@@ -1,0 +1,8 @@
+@import UIKit;
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/GagatObjectiveC/Gagat.swift
+++ b/GagatObjectiveC/Gagat.swift
@@ -43,9 +43,9 @@ public class GGTConfiguration: NSObject {
 	/// Specify a factor of 0 to entirely disable the deformation.
 	///
 	/// Defaults to 1.0.
-	public let jellyFactor: Double
+	@objc public let jellyFactor: Double
 
-	public init(jellyFactor: Double = 1.0) {
+	@objc public init(jellyFactor: Double = 1.0) {
 		self.jellyFactor = jellyFactor
 	}
 
@@ -73,7 +73,7 @@ public class GGTTransitionHandle: NSObject {
 	///
 	/// - important: You *must not* change the gesture recognizer's delegate
 	///              or remove targets not added by the client.
-	public var panGestureRecognizer: UIPanGestureRecognizer {
+	@objc public var panGestureRecognizer: UIPanGestureRecognizer {
 		return wrappedHandle.panGestureRecognizer
 	}
 }
@@ -102,7 +102,7 @@ public class GGTManager: NSObject {
 	/// - parameter configuration: The configuration to use for the transition.
 	///
 	/// - returns: A new instance of `GGTTransitionHandle`.
-	public class func configure(forWindow window: UIWindow, withStyleableObject styleableObject: GGTStyleable, usingConfiguration configuration: GGTConfiguration = GGTConfiguration()) -> GGTTransitionHandle {
+	@objc public class func configure(forWindow window: UIWindow, withStyleableObject styleableObject: GGTStyleable, usingConfiguration configuration: GGTConfiguration = GGTConfiguration()) -> GGTTransitionHandle {
 		let styleableObjectProxy = GagatStyleableSwiftToObjCProxy(target: styleableObject)
 		let handle = Gagat.configure(for: window, with: styleableObjectProxy, using: configuration.toSwiftRepresentation)
 		return GGTTransitionHandle(byWrapping: handle)


### PR DESCRIPTION
This migrates all three targets to Swift 4.2. It also removes a deprecated API call in the example app that was not needed and resulted in a warning with Xcode 10 — see https://developer.apple.com/documentation/uikit/uiapplication/1622923-setstatusbarstyle